### PR TITLE
feat: resolvePlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ module.exports = {
 
               use: [
                 /* markdown-it plugin */
-                require('markdown-it-xxx'),
+                'markdown-it-xxx',
 
                 /* or */
-                [require('markdown-it-xxx'), 'this is options']
+                ['markdown-it-xxx', 'this is options']
               ]
             }
           }

--- a/lib/core.js
+++ b/lib/core.js
@@ -73,7 +73,7 @@ module.exports = function (source) {
     if (plugins) {
       plugins.forEach(function (plugin) {
         if (Array.isArray(plugin)) {
-          plugin[0] = requirePlugin(plugin[0])
+          plugin[0] = resolvePlugin(plugin[0])
           parser.use.apply(parser, plugin)
         } else {
           parser.use(resolvePlugin(plugin))

--- a/lib/core.js
+++ b/lib/core.js
@@ -35,6 +35,18 @@ var renderVueTemplate = function (html) {
   return '<section>' + html + '</section>\n'
 }
 
+/**
+ * Resolves plguins passed as string
+ * @param {String|Object} plugin
+ * @return {Object}
+ */
+var resolvePlugin = function (plugin) {
+  if (typeof plugin === 'string') {
+    return require(plugin)
+  }
+  return plugin
+}
+
 module.exports = function (source) {
   this.cacheable()
 
@@ -42,7 +54,7 @@ module.exports = function (source) {
   var params = loaderUtils.getOptions(this)
   var opts = Object.assign({}, params)
 
-  if (typeof(opts.render) === 'function') {
+  if (typeof (opts.render) === 'function') {
     parser = opts
   } else {
     opts = Object.assign({
@@ -61,9 +73,10 @@ module.exports = function (source) {
     if (plugins) {
       plugins.forEach(function (plugin) {
         if (Array.isArray(plugin)) {
+          plugin[0] = requirePlugin(plugin[0])
           parser.use.apply(parser, plugin)
         } else {
-          parser.use(plugin)
+          parser.use(resolvePlugin(plugin))
         }
       })
     }


### PR DESCRIPTION
Hi & Thanks for your awesome work. Recently we have found a problem with vue-loader (nuxt-community/modules#63) which required items in `use` key are being nulled. This PR adds support for lazy-require plugins, so one can pass plain strings. I've forked and released fix under `@nuxtjs` BTW feel free require changes i would happy keeping upstream updated :)